### PR TITLE
Moved and updated criterion into dev-dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ fuzz/corpus
 Cargo.lock
 target
 testing_data_directories
+
+measure_throughput
+measure_latency

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ runtime_validation = ["rand"]
 [dev-dependencies]
 env_logger = "0.9.0"
 rand = "0.8.5"
+criterion = {version = "0.5.1", features = ["html_reports"]}
 
 [dependencies]
 crc32fast = "1.3.2"
@@ -34,7 +35,6 @@ zstd-safe = { version="5.0.2", features=["std", "experimental"] }
 serde = { version = "1.0.144", features = ["derive"], optional = true }
 bincode = { version = "1.3.3", optional = true }
 concurrent-map = { version ="5.0" }
-criterion = {version = "0.3.6", features = ["html_reports"], optional = true}
 
 [[bench]]
 name = "marble_bench"


### PR DESCRIPTION
this would sove the issue when running `cargo bench`, as the `criterion` is a dependency, but it seems to me and the [criterion](https://docs.rs/crate/criterion/0.5.1) docs it should be used in `dev-dependencies` section of Cargo.toml file.
